### PR TITLE
Remove pybind11 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ ecos
 scs
 numpy
 scipy
-pybind11


### PR DESCRIPTION
## Description
This change removes pybind11 from the run time dependencies list. pybind11 is only needed as a build dependency (specified in build-system.requires in pyproject.toml) and does not need to be in the run time dependencies kept in requirements.txt.

Issue link (if applicable): #2330

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [x] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.